### PR TITLE
use counter instead of pointer cast for obj id

### DIFF
--- a/src/cud.c
+++ b/src/cud.c
@@ -36,6 +36,8 @@ static RB_HEAD(cudtree_s, cud_s) Head = RB_INITIALIZER(&Head);
 
 RB_PROTOTYPE_STATIC(cudtree_s, cud_s, entry, cmp) 
 RB_GENERATE_STATIC(cudtree_s, cud_s, entry, cmp) 
+
+static uintptr_t last_cud_key=128;
  
 static cud_t *cud_remove(cud_t *cud) 
     { return RB_REMOVE(cudtree_s, &Head, cud); }
@@ -63,7 +65,7 @@ cud_t *cud_new(void)
     cud_t *cud;
     if((cud = (cud_t*)Malloc(sizeof(cud_t))) == NULL) return NULL;
     memset(cud, 0, sizeof(cud_t));
-    cud->key = (uintptr_t)cud;
+    cud->key = last_cud_key++;
     if(cud_search(cud->key))
         { Free(cud); luajack_error(UNEXPECTED_ERROR); return NULL; }
     cud->obj.type = LUAJACK_TCLIENT;

--- a/src/pud.c
+++ b/src/pud.c
@@ -34,6 +34,8 @@ static int cmp(pud_t *pud1, pud_t *pud2) /* the compare function */
 
 static RB_HEAD(pudtree_s, pud_s) Head = RB_INITIALIZER(&Head);
 
+static uintptr_t last_pud_key=1024;
+
 RB_PROTOTYPE_STATIC(pudtree_s, pud_s, entry, cmp) 
 RB_GENERATE_STATIC(pudtree_s, pud_s, entry, cmp) 
  
@@ -62,7 +64,7 @@ pud_t *pud_new(cud_t *cud)
 	pud_t *pud;
 	if((pud = (pud_t*)Malloc(sizeof(pud_t))) == NULL) return NULL;
 	memset(pud, 0, sizeof(pud_t));
-	pud->key = (uintptr_t)pud;
+	pud->key = last_pud_key++;
 	if(pud_search(pud->key))
 		{ Free(pud); luajack_error(UNEXPECTED_ERROR); return NULL; }
 	cud_fifo_insert(cud, pud);

--- a/src/rud.c
+++ b/src/rud.c
@@ -34,6 +34,8 @@ static int cmp(rud_t *rud1, rud_t *rud2) /* the compare function */
 
 static RB_HEAD(rudtree_s, rud_s) Head = RB_INITIALIZER(&Head);
 
+static uintptr_t last_rud_key=2048;
+
 RB_PROTOTYPE_STATIC(rudtree_s, rud_s, entry, cmp) 
 RB_GENERATE_STATIC(rudtree_s, rud_s, entry, cmp) 
  
@@ -63,7 +65,7 @@ rud_t *rud_new(void)
 	rud_t *rud;
 	if((rud = (rud_t*)Malloc(sizeof(rud_t))) == NULL)  return NULL;
 	memset(rud, 0, sizeof(rud_t));
-	rud->key = (uintptr_t)rud;
+	rud->key = last_rud_key++;
 	if(rud_search(rud->key))
 		{ Free(rud); luajack_error(UNEXPECTED_ERROR); return NULL; }
 	rud->obj.type = LUAJACK_TRINGBUFFER;

--- a/src/tud.c
+++ b/src/tud.c
@@ -34,6 +34,8 @@ static int cmp(tud_t *tud1, tud_t *tud2) /* the compare function */
 
 static RB_HEAD(tudtree_s, tud_s) Head = RB_INITIALIZER(&Head);
 
+static uintptr_t last_tud_key=3096;
+
 RB_PROTOTYPE_STATIC(tudtree_s, tud_s, entry, cmp) 
 RB_GENERATE_STATIC(tudtree_s, tud_s, entry, cmp) 
  
@@ -63,7 +65,7 @@ tud_t *tud_new(void)
 	tud_t *tud;
 	if((tud = (tud_t*)Malloc(sizeof(tud_t))) == NULL) return NULL;
 	memset(tud, 0, sizeof(tud_t));
-	tud->key = (uintptr_t)tud;
+	tud->key = last_tud_key++;
 	if(tud_search(tud->key))
 		{ Free(tud); luajack_error(UNEXPECTED_ERROR); return NULL; }
 	tud->obj.type = LUAJACK_TTHREAD;


### PR DESCRIPTION
On my x86_64 Debian 12 host, using lua5.4:
- object Ids are not well passed back from lua to C.
- created objects can't be found, making errors like "invalid ring buffer reference" It seems it is because lua numbers are double and the way big 64bits uintptr_t values are assigned ans cast to/from lua double does not preserve identity (in particular when pointers value are starting with 0xff, making negative value in lua side).

To solve this issue, key values are now generated with simple counters starting from specific remarkable values accoring type (128, 1024, 2048, etc). Since I do not expect so much keys shall be created from a single script, I do not expect the counters will increase so much improper values like the pointers can be reached.

To be considered: protect counter increments with mutex. Did not implemented yet since my understanding of luajack is new object shall be created from the main thread before jack.activate(), so such mutex appears to be useless.